### PR TITLE
Initial audio profile settings - identical with hard-coded ones used before

### DIFF
--- a/floppy/fdd_audio_profiles.cfg
+++ b/floppy/fdd_audio_profiles.cfg
@@ -1,0 +1,70 @@
+# 86Box Floppy Drive Audio Profiles Configuration
+# This file defines audio profiles for different floppy drive types
+
+[Profile "0"]
+id = 0
+name = None
+internal_name = none
+
+[Profile "1"]
+id = 1
+name = Generic Mitsumi 3.5" 1.44MB
+internal_name = Mitsumi
+spindlemotor_start_file = roms/floppy/samples/mitsumi_spindle_motor_start_48000_16_1_PCM.wav
+spindlemotor_start_volume = 0.2
+spindlemotor_loop_file = roms/floppy/samples/mitsumi_spindle_motor_loop_48000_16_1_PCM.wav
+spindlemotor_loop_volume = 0.2
+spindlemotor_stop_file = roms/floppy/samples/mitsumi_spindle_motor_stop_48000_16_1_PCM.wav
+spindlemotor_stop_volume = 0.2
+single_track_step_file = roms/floppy/samples/mitsumi_track_step_48000_16_1_PCM.wav
+single_track_step_volume = 1.0
+multi_track_seek_file = roms/floppy/samples/mitsumi_seek_80_tracks_495ms_48000_16_1_PCM.wav
+multi_track_seek_volume = 1.0
+samples_per_track = 297
+total_tracks = 80
+initial_seek_time = 15000.0
+initial_seek_time_pcjr = 40000.0
+track_seek_time = 6000.0
+track_seek_time_pcjr = 10000.0
+
+[Profile "2"]
+id = 2
+name = Panasonic JU-475-5 5.25" 1.2MB
+internal_name = panasonic
+spindlemotor_start_file = roms/floppy/samples/Panasonic_JU-475-5_5.25_1.2MB_motor_start_48000_16_1_PCM.wav
+spindlemotor_start_volume = 1.0
+spindlemotor_loop_file = roms/floppy/samples/Panasonic_JU-475-5_5.25_1.2MB_motor_loop_48000_16_1_PCM.wav
+spindlemotor_loop_volume = 1.0
+spindlemotor_stop_file = roms/floppy/samples/Panasonic_JU-475-5_5.25_1.2MB_motor_stop_48000_16_1_PCM.wav
+spindlemotor_stop_volume = 1.0
+single_track_step_file = roms/floppy/samples/Panasonic_JU-475-5_5.25_1.2MB_track_step_48000_16_1_PCM.wav
+single_track_step_volume = 2.0
+multi_track_seek_file = roms/floppy/samples/Panasonic_JU-475-5_5.25_1.2MB_seekup_40_tracks_285ms_5ms_per_track_48000_16_1_PCM.wav
+multi_track_seek_volume = 2.0
+samples_per_track = 342
+total_tracks = 40
+initial_seek_time = 15000.0
+initial_seek_time_pcjr = 40000.0
+track_seek_time = 6000.0
+track_seek_time_pcjr = 10000.0
+
+[Profile "3"]
+id = 3
+name = Teac FD-55GFR 5.25" 1.2MB
+internal_name = teac
+spindlemotor_start_file = roms/floppy/samples/TeacFD-55GFR_5.25_1.2MB_motor_start_48000_16_1_PCM.wav
+spindlemotor_start_volume = 3.0
+spindlemotor_loop_file = roms/floppy/samples/TeacFD-55GFR_5.25_1.2MB_motor_loop_48000_16_1_PCM.wav
+spindlemotor_loop_volume = 3.0
+spindlemotor_stop_file = roms/floppy/samples/TeacFD-55GFR_5.25_1.2MB_motor_stop_48000_16_1_PCM.wav
+spindlemotor_stop_volume = 3.0
+single_track_step_file = roms/floppy/samples/TeacFD-55GFR_5.25_1.2MB_track_step_48000_16_1_PCM.wav
+single_track_step_volume = 2.0
+multi_track_seek_file = roms/floppy/samples/TeacFD_55GFR_5.25_1.2MB_seekupdown_80_tracks1100ms_48000_16_1_PCM.wav
+multi_track_seek_volume = 2.0
+samples_per_track = 342
+total_tracks = 80
+initial_seek_time = 15000.0
+initial_seek_time_pcjr = 40000.0
+track_seek_time = 6000.0
+track_seek_time_pcjr = 10000.0


### PR DESCRIPTION
Add fdd_audio_profiles.cfg to the roms/floppy. 86box settings will populate floppy diskl audio selection dropdown based on this config and the fdd ja fdd_audio emulation will use timing values provided by this configration. Mainly seek-timings.

# Description:

Config file to defined fdd_audio_profiles to be used with fdd sound emulation.

# Checklist:
- [x] I have opened a pull request in the main 86Box repository.
- [x] I have not added any unrelated files to this pull request.
- [x] My commit(s) follow the [committing guidelines](https://github.com/86Box/roms#committing-guidelines).

# Your 86Box pull request:
https://github.com/86Box/86Box/pull/6263
